### PR TITLE
Added Node 6.10 runtime

### DIFF
--- a/lib/RuntimeNode610.js
+++ b/lib/RuntimeNode610.js
@@ -1,0 +1,21 @@
+'use strict';
+
+
+const BbPromise = require('bluebird');
+const _         = require('lodash');
+const chalk     = require('chalk');
+
+const SCli      = require('./utils/cli');
+const context      = require('./utils/context');
+
+module.exports = function(S) {
+
+  return class RuntimeNode610 extends S.classes.RuntimeNode43 {
+
+    static getName() {
+      return 'nodejs6.10';
+    }
+
+  }
+
+};

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -45,6 +45,7 @@ class Serverless {
     this.classes.Runtime            = require('./Runtime')(this);
     this.classes.RuntimeNode        = require('./RuntimeNode')(this);
     this.classes.RuntimeNode43      = require('./RuntimeNode43')(this);
+    this.classes.RuntimeNode610     = require('./RuntimeNode610')(this);
     this.classes.RuntimePython27    = require('./RuntimePython27')(this);
 
     // Add Config Settings


### PR DESCRIPTION
Added support for Node 6.10 runtime setting. Now you can specify `nodejs6.10` as runtime and it will be set accordingly for the function.

Note: When using Node 6 to package a service, you still have to use the `--legacy-bundling` option with `npm install`, as long as you've still 4.3 based functions in your service.